### PR TITLE
Option to remove named export from auto-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,24 @@ Then add this plugin in `tsconfig.json`.
 ### paths (required)
 
 Specify directory in relative path to the project's root (`tsconfig.json`'s dir). All `.ts` or `.js` files in the directories can be Namespace Imported with auto-completion.
+
+example:
+
+```json
+"options": {
+  "paths": ["src/logics"]
+}
+```
+
+### ignoreNamedExport
+
+If true, named export from files in `paths` won't be shown in auto-completion.
+
+example:
+
+```json
+"options": {
+  "paths": ["src/logics"],
+  "ignoreNamedExport": true
+}
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,9 @@ function init() {
         return original;
       }
 
-      original.entries = [...original.entries, ...namespaceImportPlugin.getCompletionEntries(info)];
+      const originalEntries = namespaceImportPlugin.filterNamedImportEntries(original.entries, info);
+      const namespaceImportEntries = namespaceImportPlugin.getCompletionEntries(info);
+      original.entries = [...originalEntries, ...namespaceImportEntries];
       return original;
     };
 

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -88,7 +88,7 @@ function transformModulePath(selfPath: string, filePath: string, project: ts.ser
   }
 }
 
-export function getCodeFixActionFromPath(
+function getCodeFixActionFromPath(
   name: string,
   selfPath: string,
   modulePath: string,


### PR DESCRIPTION
Resolve #3. Add `ignoreNamedExport` option.