### PR TITLE
Do not show auto-completion when triggered by char

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ function init() {
     info.languageService.getCompletionsAtPosition = (fileName, position, options) => {
       log('getCompletionsAtPosition', { fileName, position, options });
       const original = getCompletionsAtPosition(fileName, position, options);
-      if (original == null) {
+      if (original == null || options?.triggerCharacter != null) {
         return original;
       }
 


### PR DESCRIPTION
Don't show namespace import completion when triggered by char like `.` because namespace won't be there.