### PR TITLE
Use slash as path separator on Windows

### DIFF
--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -114,9 +114,9 @@ function getModuleSpceifier(selfPath: string, modulePath: string, project: ts.se
 
   let specifier: string;
   if (compilerOptions.baseUrl) {
-    specifier = path.relative(compilerOptions.baseUrl, modulePath);
+    specifier = path.posix.relative(compilerOptions.baseUrl, modulePath);
   } else {
-    specifier = './' + path.relative(path.dirname(selfPath), modulePath);
+    specifier = './' + path.posix.relative(path.dirname(selfPath), modulePath);
   }
 
   return getFilePathWithoutExt(specifier);


### PR DESCRIPTION
This PR fixes the issue that inserted path contains `\` (backslash) instead of `/` on Windows.

For example:

```ts
// latest (v0.3.2)
import * as AnotherLogics from "./logics\AnotherLogics";

// fixed
import * as AnotherLogics from "./logics/AnotherLogics";
```
